### PR TITLE
Support special username in Redis AUTH

### DIFF
--- a/options.go
+++ b/options.go
@@ -10,6 +10,7 @@ type WatcherOptions struct {
 	Channel            string
 	PubConn            redis.Conn
 	SubConn            redis.Conn
+	Username           string
 	Password           string
 	Protocol           string
 	IgnoreSelf         bool
@@ -26,6 +27,12 @@ type WatcherOption func(*WatcherOptions)
 func Channel(subject string) WatcherOption {
 	return func(options *WatcherOptions) {
 		options.Channel = subject
+	}
+}
+
+func Username(username string) WatcherOption {
+	return func(options *WatcherOptions) {
+		options.Username = username
 	}
 }
 

--- a/options_test.go
+++ b/options_test.go
@@ -7,6 +7,7 @@ func TestOptions(t *testing.T) {
 		Channel:  "ch1",
 		Password: "pa1",
 		Protocol: "pr1",
+		Username: "user1",
 	}
 
 	// test single option
@@ -16,12 +17,16 @@ func TestOptions(t *testing.T) {
 		t.Errorf("Channel should be 'ch2', received '%s' instead", o.Channel)
 	}
 
+	if o.Username != "user1" {
+		t.Errorf("Username should be 'user1', received '%s' instead", o.Username)
+	}
+
 	if o.Password != "pa1" {
 		t.Errorf("Password should be 'pa1', received '%s' instead", o.Password)
 	}
 
 	// test multiple options
-	o.optionBuilder(Channel("ch3"), Password("pa3"), Protocol("pr3"))
+	o.optionBuilder(Channel("ch3"), Password("pa3"), Protocol("pr3"), Username("user3"))
 
 	if o.Channel != "ch3" {
 		t.Errorf("Channel should be 'ch3', received '%s' instead", o.Channel)
@@ -33,6 +38,10 @@ func TestOptions(t *testing.T) {
 
 	if o.Protocol != "pr3" {
 		t.Errorf("Protocol should be 'pr3', received '%s' instead", o.Password)
+	}
+
+	if o.Username != "user3" {
+		t.Errorf("Username should be 'user3', received '%s' instead", o.Username)
 	}
 }
 

--- a/watcher.go
+++ b/watcher.go
@@ -231,7 +231,14 @@ func (w *Watcher) dial(addr string) (*redis.Conn, error) {
 	}
 	if w.options.Password != "" {
 		startTime = time.Now()
-		_, err = c.Do("AUTH", w.options.Password)
+
+		// https://redis.io/commands/auth
+		username := "default"
+		if w.options.Username != "" {
+			username = w.options.Username
+		}
+
+		_, err = c.Do("AUTH", username, w.options.Password)
 		if err != nil {
 			if w.options.RecordMetrics != nil {
 				w.options.RecordMetrics(w.createMetrics(RedisDoAuthMetric, startTime, err))


### PR DESCRIPTION
@billcobbler My project needs to use a special username to connect Redis
Can you help to review this PR?
Some changes:
- Add Username in options
- Check username when validating Redis AUTH
- username: The default value is `default`
- Update UTs